### PR TITLE
use '> /dev/null 2>&1' for compatibility.

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -45,6 +45,10 @@ node server.js --cert ../certs/rtc.liweix.com.pem --key ../certs/rtc.liweix.com.
 ```
 node server.js --cert ../certs/rtc.liweix.com.pem --key ../certs/rtc.liweix.com.key --publicIp x.x.x.x
 ```
+* ```eth0``` is used as default interface name. If you have a different interface name, you must specify it using ```--eth```
+```
+node server.js --cert ../certs/rtc.liweix.com.pem --key ../certs/rtc.liweix.com.key --eth <ifname>
+```
 * Or you can run start.sh with default SSL certificate
 ```
 ./start.sh

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ node server.js --cert ../certs/rtc.liweix.com.pem --key ../certs/rtc.liweix.com.
 
 # 如果获取公网IP地址失败,则可以使用--publicIp 手动提供公网IP地址
 node server.js --cert ../certs/rtc.liweix.com.pem --key ../certs/rtc.liweix.com.key --publicIp x.x.x.x
+
+# 默认使用网卡名称 eth0 ，如果你的网卡名不同，须用 --eth 指定
+node server.js --cert ../certs/rtc.liweix.com.pem --key ../certs/rtc.liweix.com.key --eth <ifname>
 ```
 
 ## 方法二： 直接运行start.sh(使用默认证书)

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #! /bin/sh
 
-if command -v cnpm &> /dev/null; then
+if command -v cnpm > /dev/null 2>&1; then
 	alias npm_command='cnpm'
-elif command -v npm &> /dev/null; then
+elif command -v npm > /dev/null 2>&1; then
 	alias npm_command='npm'
 fi
 
@@ -19,8 +19,8 @@ if [ "$node_version" \< "v12" ]; then
 	exit -1;
 fi
 
-mkdir dist
-mkdir -p /var/run/wilearning/public/
+mkdir -p dist
+#mkdir -p /var/run/wilearning/public/
 
 # build server
 build_server() {
@@ -37,7 +37,7 @@ build_server() {
 	fi
 
 	cp -a dist/* ../dist/
-	ln -s `pwd`/node_modules ../dist/
+	ln -s $PWD/node_modules ../dist/
 	cd ..
 }
 
@@ -76,7 +76,7 @@ build_admin() {
 case "$1" in
 	all)
 		rm -rf dist/
-		mkdir dist
+		mkdir -p dist
 		build_server
 		build_admin
 		build_app


### PR DESCRIPTION
 /bin/sh on debian links to dash which doesn't support &> and will cause if test always be true.
There is no need to use command substitution, $PWD will be fine.
Use mkdir -p to suppress directory already exists error.
Since /var/run/wilearning/public/ will be created when start the server. We don't need to create it in build.sh so we won't see the permisson error.