### PR TITLE
disable camera/mic button after click

### DIFF
--- a/app/src/app/chat/chat.component.scss
+++ b/app/src/app/chat/chat.component.scss
@@ -35,3 +35,8 @@ ion-content {
     justify-content: center;
     align-items: flex-end;
 }
+
+.chat-list{
+    height: 100%;
+    overflow-y: auto;
+}

--- a/app/src/app/main/main.component.html
+++ b/app/src/app/main/main.component.html
@@ -91,17 +91,17 @@
       <ion-footer class="ion-no-border">
         <ion-toolbar>
           <ion-buttons class="ion-justify-content-around">
-            <ion-button *ngIf="!peer.isEnableCamera(profile.me)" (click)="produceLocalCamera()">
+            <ion-button *ngIf="!peer.isEnableCamera(profile.me)" (click)="produceLocalCamera();videoBtn.disabled=true" #videoBtn>
               <ion-icon slot="icon-only" src="assets/img/videocam-off.svg"></ion-icon>
             </ion-button>
-            <ion-button *ngIf="peer.isEnableCamera(profile.me)" (click)="peer.stopLocalCamera()" >
+            <ion-button *ngIf="peer.isEnableCamera(profile.me)" (click)="peer.stopLocalCamera();videoBtn.disabled=false" >
               <ion-icon slot="icon-only" name="videocam"></ion-icon>
             </ion-button>
 
-            <ion-button *ngIf="!peer.isEnableMic(profile.me)" (click)="produceLocalMic()">
+            <ion-button *ngIf="!peer.isEnableMic(profile.me)" (click)="produceLocalMic();micBtn.disabled = true" #micBtn>
               <ion-icon slot="icon-only" name="mic-off"></ion-icon>
             </ion-button>
-            <ion-button *ngIf="peer.isEnableMic(profile.me)" (click)="peer.stopLocalMic()">
+            <ion-button *ngIf="peer.isEnableMic(profile.me)" (click)="peer.stopLocalMic();micBtn.disabled=fasle">
               <ion-icon slot="icon-only" name="mic"></ion-icon>
             </ion-button>
 


### PR DESCRIPTION
快速点击视频按钮会产生多个 producerId ，但关闭只会关闭最后一个。导致你以为视频关闭了，其实还开着。后面进入房间的人可以看到你！危险！